### PR TITLE
Support keyworded keys via `keywordize?`

### DIFF
--- a/examples/cue/policy.clj
+++ b/examples/cue/policy.clj
@@ -3,7 +3,7 @@
 (defn deny-apps-not-using-v1
   [input]
   (let [api-version (:apiVersion input)
-        name (-> input :metadata :name)]
+        name (get-in input [:metadata :name])]
     (when-not (= api-version "apps/v1")
       (format "apiVersion must be apps/v1 in '%s'" name))))
 
@@ -24,6 +24,6 @@
 
 (defn deny-no-images-tagged
   [input]
-  (let [containers (-> input :spec :template :spec :containers)]
+  (let [containers (get-in input [:spec :template :spec :containers])]
     (when-not (seq (filter #(clojure.string/ends-with? (:image %) ":latest") containers))
       "No images tagged latest")))

--- a/examples/cue/policy.clj
+++ b/examples/cue/policy.clj
@@ -2,28 +2,28 @@
 
 (defn deny-apps-not-using-v1
   [input]
-  (let [api-version (get input "apiVersion")
-        name (get-in input ["metadata" "name"])]
+  (let [api-version (:apiVersion input)
+        name (-> input :metadata :name)]
     (when-not (= api-version "apps/v1")
       (format "apiVersion must be apps/v1 in '%s'" name))))
 
 (defn deny-replica-count-less-than-2
   [input]
-  (let [replicas (get-in input ["spec" "replicas"])]
+  (let [replicas (get-in input [:spec :replicas])]
     (when (< replicas 2)
       (format "Replica count must be greater than 2, you have %f" replicas))))
 
 (defn deny-ports-outside-of-8080
   [input]
-  (let [containers (get-in input ["spec" "template" "spec" "containers"])
+  (let [containers (get-in input [:spec :template :spec :containers])
         ports (->> containers
-                   (mapcat #(get % "ports"))
-                   (mapv #(get % "containerPort")))]
+                   (mapcat :ports)
+                   (mapv :containerPort))]
     (when-not (every? (partial = 8080.0) ports)
       (format "The image port should be 8080 in deployment.cue. you have: %s" ports))))
 
 (defn deny-no-images-tagged
   [input]
-  (let [containers (get-in input ["spec" "template" "spec" "containers"])]
-    (when-not (seq (filter #(clojure.string/ends-with? (get % "image") ":latest") containers))
+  (let [containers (-> input :spec :template :spec :containers)]
+    (when-not (seq (filter #(clojure.string/ends-with? (:image %) ":latest") containers))
       "No images tagged latest")))

--- a/examples/dockerfile/policy.clj
+++ b/examples/dockerfile/policy.clj
@@ -6,11 +6,11 @@
 (defn deny-unallowed-commands
   [input]
   (distinct (for [dockerfile input
-                  command dockerfile
-                  value (get command "Value")
+                  {:keys [Cmd] :as command} dockerfile
+                  value (:Value command)
                   re cmd-denylist
                   :let [eval-result (re-find re value)]
-                  :when (and (= "run" (get command "Cmd"))
+                  :when (and (= "run" Cmd)
                              (not (nil? eval-result)))]
               (format "unallowed command found '%s'" value))))
 
@@ -20,10 +20,10 @@
 (defn deny-unallowed-images
   [input]
   (for [dockerfile input
-        command dockerfile
-        value (get command "Value")
+        {:keys [Cmd] :as command} dockerfile
+        value (:Value command)
         re image-denylist
         :let [eval-result (re-find re value)]
-        :when (and (= "from" (get command "Cmd"))
+        :when (and (= "from" Cmd)
                    (not (nil? eval-result)))]
     (format "unallowed image found '%s'" value)))

--- a/examples/dotenv/policy.clj
+++ b/examples/dotenv/policy.clj
@@ -2,10 +2,10 @@
 
 (defn deny-empty-app-name
   [input]
-  (when (empty? (get input "APP_NAME"))
+  (when (empty? (:APP_NAME input))
     "APP_NAME must be set"))
 
 (defn deny-root-user
   [input]
-  (when (= "root" (get input "MYSQL_USER"))
+  (when (= "root" (:MYSQL_USER input))
     "MYSQL_USER should not be root"))

--- a/examples/edn/policy_go.clj
+++ b/examples/edn/policy_go.clj
@@ -2,12 +2,12 @@
 
 (defn deny-incorrect-log-level-development
   [input]
-  (when (and (= ":development" (get input ":env"))
-             (not= ":debug" (get input ":log")))
+  (when (and (= ":development" (:env input))
+             (not= ":debug" (:log input)))
     "Applications in the development environment should have debug logging"))
 
 (defn deny-incorrect-log-level-production
   [input]
-  (when (and (= ":production" (get input ":env"))
-             (not= ":error" (get input ":log")))
+  (when (and (= ":production" (:env input))
+             (not= ":error" (:log input)))
     "Applications in the production environment should have error only logging"))

--- a/examples/hcl1/combined_policy.clj
+++ b/examples/hcl1/combined_policy.clj
@@ -2,6 +2,6 @@
 
 (defn deny-missing-path
   [input]
-  (when (not= "instrumenta" (or (get-in input ["provider" "google" "project"])
+  (when (not= "instrumenta" (or (get-in input [:provider :google :project])
                                 (get-in input [:configuration :provider_config :google :expressions :project :constant_value])))
     "File path index to key value does not exist"))

--- a/examples/hcl1/tf_policy.clj
+++ b/examples/hcl1/tf_policy.clj
@@ -2,5 +2,5 @@
 
 (defn deny-no-resources
   [input]
-  (when (empty? (get input "resource"))
+  (when (empty? (:resource input))
     (format "could not find any resources in: %s" input)))

--- a/examples/hcl2/policy.clj
+++ b/examples/hcl2/policy.clj
@@ -2,36 +2,36 @@
 
 (defn deny-http
   [input]
-  (for [[alb-listener-name alb-listener] (get-in input ["resource" "aws_alb_listener"])
-        :when (= "HTTP" (get alb-listener "protocol"))]
+  (for [[alb-listener-name alb-listener] (get-in input [:resource :aws_alb_listener])
+        :when (= "HTTP" (:protocol alb-listener))]
     (format "ALB listener '%s' is using HTTP rather than HTTPS" alb-listener-name)))
 
 (defn deny-fully-open-ingress
   [input]
-  (for [[rule-name security-group-rule] (get-in input ["resource" "aws_security_group_rule"])
-        cidr-block (get security-group-rule "cidr_blocks")
-        :when (and (= "ingress" (get security-group-rule "type"))
+  (for [[rule-name security-group-rule] (get-in input [:resource :aws_security_group_rule])
+        cidr-block (:cidr_blocks security-group-rule)
+        :when (and (= "ingress" (:type security-group-rule))
                    (= "0.0.0.0/0" cidr-block))]
     (format "ASG rule '%s' defines a fully open ingress" rule-name)))
 
 (defn deny-unencrypted-azure-disk
   [input]
-  (for [[disk-name disk] (get-in input ["resource" "azurerm_managed_disk"])
-        :let [encryption-settings (get disk "encryption_settings")]
-        :when (not (true? (get encryption-settings "enabled")))]
+  (for [[disk-name disk] (get-in input [:resource :azurerm_managed_disk])
+        :let [encryption-settings (:encryption_settings disk)]
+        :when (not (true? (:enabled encryption-settings)))]
     (format "Azure disk '%s' is not encrypted" disk-name)))
 
-(def ^:private required-tags #{"environment" "owner"})
+(def ^:private required-tags #{:environment :owner})
 
 (defn deny-missing-tags
   [input]
-  (sort (for [[resource-type resources] (get input "resource")
+  (sort (for [[resource-type resources] (:resource input)
               [resource-name resource-definition] resources
-              :let [tags (into #{} (keys (get resource-definition "tags")))
+              :let [tags (into #{} (keys (:tags resource-definition)))
                     missing-tags (clojure.set/difference
                                    (clojure.set/union tags required-tags)
                                    tags)]
-              :when (and (clojure.string/starts-with? resource-type "aws_")
+              :when (and (clojure.string/starts-with? (name resource-type) "aws_")
                          (pos? (count missing-tags)))]
           (format "AWS resource: %s named '%s' is missing required tags: %s"
                   resource-type

--- a/examples/hocon/policy.clj
+++ b/examples/hocon/policy.clj
@@ -2,10 +2,10 @@
 
 (defn deny-wrong-port
   [input]
-  (when (not= 9000.0 (get-in input ["play" "server" "http" "port"]))
+  (when (not= 9000.0 (get-in input [:play :server :http :port]))
     "Play http server port should be 9000"))
 
 (defn deny-http-bind-address
   [input]
-  (when (not= "0.0.0.0" (get-in input ["play" "server" "http" "address"]))
+  (when (not= "0.0.0.0" (get-in input [:play :server :http :address]))
     "Play http server bind address should be 0.0.0.0"))

--- a/examples/ignore/dockerignore/policy.clj
+++ b/examples/ignore/dockerignore/policy.clj
@@ -3,7 +3,7 @@
 (defn deny-git-not-ignored
   [input]
   (let [matches (for [document input
-                      {kind "Kind" value "Value" :as entry} document
+                      {kind :Kind value :Value :as entry} document
                       :when (and (= kind "Path")
                                  (= value ".git"))]
                   entry)]

--- a/examples/ignore/gitignore/policy.clj
+++ b/examples/ignore/gitignore/policy.clj
@@ -3,7 +3,7 @@
 (defn deny-no-id-rsa-files-ignored
   [input]
   (let [matches (for [document input
-                      {kind "Kind" value "Value" :as entry} document
+                      {kind :Kind value :Value :as entry} document
                       :when (and (= kind "Path")
                                  (= value "id_rsa"))]
                   entry)]

--- a/examples/ini/policy.clj
+++ b/examples/ini/policy.clj
@@ -2,30 +2,30 @@
 
 (defn deny-alerting-disabled
   [input]
-  (when (not (true? (get-in input ["alerting" "enabled"])))
+  (when (not (true? (get-in input [:alerting :enabled])))
     "Alerting should turned on"))
 
 (defn deny-basic-auth-disabled
   [input]
-  (when (not (true? (get-in input ["auth.basic" "enabled"])))
+  (when (not (true? (get-in input [:auth.basic :enabled])))
     "Basic auth should be enabled"))
 
 (defn deny-incorrect-port
   [input]
-  (when (not= 3000.0 (get-in input ["server" "http_port"]))
+  (when (not= 3000.0 (get-in input [:server :http_port]))
     "Grafana port should be 3000"))
 
 (defn deny-server-protocol
   [input]
-  (when (not= "http" (get-in input ["server" "protocol"]))
+  (when (not= "http" (get-in input [:server :protocol]))
     "Grafana should use default http"))
 
 (defn deny-allow-sign-up
   [input]
-  (when (not (false? (get-in input ["users" "allow_sign_up"])))
+  (when (not (false? (get-in input [:users :allow_sign_up])))
     "Users cannot sign up themselves"))
 
 (defn deny-verify-email-disabled
   [input]
-  (when (not (true? (get-in input ["users" "verify_email_enabled"])))
+  (when (not (true? (get-in input [:users :verify_email_enabled])))
     "Users should verify their e-mail address"))

--- a/examples/json/policy_go.clj
+++ b/examples/json/policy_go.clj
@@ -2,6 +2,6 @@
 
 (defn deny-caret-ranges
   [input]
-  (for [[_lib-name lib-version :as lib] (get input "dependencies")
+  (for [[_lib-name lib-version :as lib] (:dependencies input)
         :when (clojure.string/starts-with? lib-version "^")]
     (format "caret ranges not allowed, offending library: %s" lib)))

--- a/examples/jsonnet/policy.clj
+++ b/examples/jsonnet/policy.clj
@@ -2,10 +2,10 @@
 
 (defn deny-concat-array
   [input]
-  (when-not (< (count (get-in input ["concat_array"])) 3)
+  (when-not (< (count (:concat_array input)) 3)
     "Concat array should be less than 3"))
 
 (defn deny-obj-member
   [input]
-  (when (not (true? (get-in input ["obj_member"])))
+  (when (not (true? (:obj_member input)))
     "Object member should be true"))

--- a/examples/properties/policy.clj
+++ b/examples/properties/policy.clj
@@ -3,13 +3,13 @@
 (defn deny-invalid-uri
   [input]
   (for [[key value] input
-        :when (and (clojure.string/includes? (clojure.string/lower-case key) "url")
+        :when (and (clojure.string/includes? (clojure.string/lower-case (name key)) "url")
                    (not (clojure.string/includes? (clojure.string/lower-case value) "http")))]
     (format "Must have a valid uri defined '%s'" value)))
 
 (defn deny-secrets
   [input]
   (for [[key _value] input
-        :when (and (not= "secret.value.exception" key)
-                   (clojure.string/includes? (clojure.string/lower-case key) "secret"))]
+        :when (and (not= "secret.value.exception" (name key))
+                   (clojure.string/includes? (clojure.string/lower-case (name key)) "secret"))]
     (format "'%s' may contain a secret value" key)))

--- a/examples/spdx/policy.clj
+++ b/examples/spdx/policy.clj
@@ -3,7 +3,7 @@
 (defn deny-incorrect-license
   [input]
   (let [expected-data-license "correct-license"
-        actual-data-license (get input "dataLicense")]
+        actual-data-license (:dataLicense input)]
     (when-not (= expected-data-license actual-data-license)
       (format "DataLicense should be '%s', but found '%s'"
               expected-data-license

--- a/examples/toml/traefik/policy.clj
+++ b/examples/toml/traefik/policy.clj
@@ -3,6 +3,6 @@
 (defn deny-disallowed-ciphers
   [input]
   (let [disallowed-ciphers #{"TLS_RSA_WITH_AES_256_GCM_SHA384"}
-        ciphers (into #{} (get-in input ["entryPoints" "http" "tls" "cipherSuites"]))]
+        ciphers (into #{} (get-in input [:entryPoints :http :tls :cipherSuites]))]
     (when (not (empty? (clojure.set/intersection disallowed-ciphers ciphers)))
       (format "Following ciphers are not allowed: %s", (into [] disallowed-ciphers)))))

--- a/examples/vcl/policy.clj
+++ b/examples/vcl/policy.clj
@@ -3,12 +3,12 @@
 (defn deny-purge-list
   [input]
   (let [allowlist #{"127.0.0.1" "localhost"}
-        purges (get-in input ["acl" "purge"])]
+        purges (get-in input [:acl :purge])]
     (for [purge purges
           :when (not (allowlist purge))]
       (format "acl purge should be one of %s, was %s instead" (into [] allowlist) purge))))
 
 (defn deny-incorrect-port
   [input]
-  (when (not= "8080" (get-in input ["backend" "app" "port"]))
+  (when (not= "8080" (get-in input [:backend :app :port]))
     "default backend port should be 8080"))

--- a/examples/xml/cyclonedx/policy.clj
+++ b/examples/xml/cyclonedx/policy.clj
@@ -3,6 +3,6 @@
 (defn deny-incorrect-sha
   [input]
   (let [expected-version "sha256:d7ec60cf8390612b360c857688b383068b580d9a6ab78417c9493170ad3f1616"
-        version (get-in input ["bom" "metadata" "component" "version"])]
+        version (get-in input [:bom :metadata :component :version])]
     (when (not= version expected-version)
       (format "current SHA256 %s is not equal to expected SHA256 %s" version expected-version))))

--- a/examples/xml/policy.clj
+++ b/examples/xml/policy.clj
@@ -3,22 +3,22 @@
 (defn deny-incorrect-compiler-plugin-version
   [input]
   (let [expected-version "3.6.1"]
-    (for [plugin (get-in input ["project" "build" "plugins" "plugin"])
-          :when (and (= (get plugin "artifactId") "maven-compiler-plugin")
-                     (not= (get plugin "version") expected-version))]
+    (for [plugin (get-in input [:project :build :plugins :plugin])
+          :when (and (= (:artifactId plugin) "maven-compiler-plugin")
+                     (not= (:version plugin) expected-version))]
       (format "maven-compiler-plugin must have the following version: %s" expected-version))))
 
 (defn deny-missing-instrument-goal
   [input]
-  (for [plugin (get-in input ["project" "build" "plugins" "plugin"])
-        :when (and (= (get plugin "artifactId") "activejdbc-instrumentation")
-                   (not= "instrument" (get-in plugin ["executions" "execution" "goals" "goal"])))]
+  (for [plugin (get-in input [:project :build :plugins :plugin])
+        :when (and (= (:artifactId plugin) "activejdbc-instrumentation")
+                   (not= "instrument" (get-in plugin [:executions :execution :goals :goal])))]
     (format "activejdbc-instrumentation plugin must have 'instrument' goal")))
 
 (defn deny-incorrect-surefire-plugin-version
   [input]
   (let [expected-version "2.18.1"]
-    (for [plugin (get-in input ["project" "build" "plugins" "plugin"])
-          :when (and (= (get plugin "artifactId") "maven-surefire-plugin")
-                     (not= (get plugin "version") expected-version))]
+    (for [plugin (get-in input [:project :build :plugins :plugin])
+          :when (and (= (:artifactId plugin) "maven-surefire-plugin")
+                     (not= (:version plugin) expected-version))]
       (format "maven-surefire-plugin must have the following version: %s" expected-version))))

--- a/examples/yaml/awssam/policy_go.clj
+++ b/examples/yaml/awssam/policy_go.clj
@@ -15,31 +15,31 @@
 (defn deny-python2.7
   [input]
   (when (get-in input
-                ["Resources"
-                 "LambdaFunction"
-                 "Properties"
-                 "Runtime"])
+                [:Resources
+                 :LambdaFunction
+                 :Properties
+                 :Runtime])
     "python2.7 runtime not allowed"))
 
 (defn deny-denylisted-runtimes
   [input]
   (let [runtime (get-in input
-                        ["Resources"
-                         "LambdaFunction"
-                         "Properties"
-                         "Runtime"])]
+                        [:Resources
+                         :LambdaFunction
+                         :Properties
+                         :Runtime])]
     (when (contains? runtime-denylist runtime)
       (format "'%s' runtime not allowed" runtime))))
 
 (defn deny-excessive-action-permissions
   [input]
-  (let [policies (get-in input ["Resources"
-                                "LambdaFunction"
-                                "Properties"
-                                "Policies"])]
-    (when (not-empty (filter (fn [{statements "Statement"}]
-                               (some (fn [{actions "Action"
-                                           effect "Effect"}]
+  (let [policies (get-in input [:Resources
+                                :LambdaFunction
+                                :Properties
+                                :Policies])]
+    (when (not-empty (filter (fn [{statements :Statement}]
+                               (some (fn [{actions :Action
+                                           effect :Effect}]
                                        (and (= effect "Allow")
                                             (ends-with? denylist actions)))
                                      statements)) policies))
@@ -47,13 +47,13 @@
 
 (defn deny-excessive-resource-permissions
   [input]
-  (let [policies (get-in input ["Resources"
-                                "LambdaFunction"
-                                "Properties"
-                                "Policies"])]
-    (when (not-empty (filter (fn [{statements "Statement"}]
-                               (some (fn [{resources "Resource"
-                                           effect "Effect"}]
+  (let [policies (get-in input [:Resources
+                                :LambdaFunction
+                                :Properties
+                                :Policies])]
+    (when (not-empty (filter (fn [{statements :Statement}]
+                               (some (fn [{resources :Resource
+                                           effect :Effect}]
                                        (and (= effect "Allow")
                                             (ends-with? denylist resources)))
                                      statements)) policies))
@@ -61,10 +61,10 @@
 
 (defn deny-sensitive-environment-variables
   [input]
-  (let [variables (get-in input ["Resources"
-                                "LambdaFunction"
-                                "Properties"
-                                "Environment"
-                                "Variables"])]
+  (let [variables (get-in input [:Resources
+                                 :LambdaFunction
+                                 :Properties
+                                 :Environment
+                                 :Variables])]
     (when (seq (filter (fn [x] (some (fn [y] (re-find y x)) sensitive-denylist)) variables))
       "Sensitive data not allowed in environment variables")))

--- a/examples/yaml/combine/policy_go.clj
+++ b/examples/yaml/combine/policy_go.clj
@@ -2,17 +2,17 @@
 
 (defn- deployment-matches-service-name?
   [service app]
-  (= app (get-in service ["spec" "selector" "app"])))
+  (= app (get-in service [:spec :selector :app])))
 
 (defn deny-deployments-with-no-matching-service
   [inputs]
-  (let [{services "Service" deployments "Deployment"} (group-by #(get % "kind") inputs)]
+  (let [{services "Service" deployments "Deployment"} (group-by :kind inputs)]
     (for [service services
           deployment deployments
           :when (not (deployment-matches-service-name?
                        service
-                       (get-in deployment ["spec"
-                                           "selector"
-                                           "matchLabels"
-                                           "app"])))]
-      (format "Deployment '%s' has no matching service" (get-in deployment ["metadata" "name"])))))
+                       (get-in deployment [:spec
+                                           :selector
+                                           :matchLabels
+                                           :app])))]
+      (format "Deployment '%s' has no matching service" (get-in deployment [:metadata :name])))))

--- a/examples/yaml/dockercompose/policy_go.clj
+++ b/examples/yaml/dockercompose/policy_go.clj
@@ -2,13 +2,13 @@
 
 (defn deny-latest-tags
   [input]
-  (let [services (get-in input ["services"])
-        images (->> services vals (keep #(get % "image")))]
+  (let [services (:services input)
+        images (->> services vals (keep :image))]
     (when (seq (filter #(clojure.string/ends-with? % ":latest") images))
       "No images tagged latest")))
 
 (defn deny-old-compose-versions
   [input]
-  (let [version (parse-double (get input "version"))]
+  (let [version (parse-double (:version input))]
     (when (< version 3.5)
       "Must be using at least version 3.5 of the Compose file format")))

--- a/examples/yaml/kubernetes/policy_go.clj
+++ b/examples/yaml/kubernetes/policy_go.clj
@@ -2,28 +2,28 @@
 
 (defn- deployment?
   [input]
-  (= "Deployment" (get-in input ["kind"])))
+  (= "Deployment" (:kind input)))
 
 (defn deny-should-not-run-as-root
   [input]
-  (let [name (get-in input ["metadata" "name"])]
+  (let [name (get-in input [:metadata :name])]
     (when (and (deployment? input)
-               (not (true? (get-in input ["spec"
-                                          "template"
-                                          "spec"
-                                          "securityContext"
-                                          "runAsNonRoot"]))))
+               (not (true? (get-in input [:spec
+                                          :template
+                                          :spec
+                                          :securityContext
+                                          :runAsNonRoot]))))
       (format "Containers must not run as root in Deployment \"%s\"" name))))
 
 (defn- contains-required-deployment-selectors?
   [input]
-  (let [match-labels (get-in input ["spec" "selector" "matchLabels"])]
-    (and (get match-labels "app")
-         (get match-labels "release"))))
+  (let [match-labels (get-in input [:spec :selector :matchLabels])]
+    (and (:app match-labels)
+         (:release match-labels))))
 
 (defn deny-missing-required-deployment-selectors
   [input]
-  (let [name (get-in input ["metadata" "name"])]
+  (let [name (get-in input [:metadata :name])]
     (when (and (deployment? input)
                (not (contains-required-deployment-selectors? input)))
       (format "Deployment \"%s\" must provide app/release labels for pod selectors" name))))

--- a/examples/yaml/serverless/policy_go.clj
+++ b/examples/yaml/serverless/policy_go.clj
@@ -2,17 +2,17 @@
 
 (defn deny-python2.7
   [input]
-  (when (= "python2.7" (get-in input ["provider" "runtime"]))
+  (when (= "python2.7" (get-in input [:provider :runtime]))
     "Python 2.7 cannot be the default provider runtime"))
 
 (defn deny-functions-python2.7
   [input]
-  (when (seq (for [[_ function] (get input "functions")
-                   :when (= "python2.7" (get function "runtime"))]
+  (when (seq (for [[_ function] (:functions input)
+                   :when (= "python2.7" (:runtime function))]
                function))
     "Python 2.7 cannot be used as the runtime for functions"))
 
 (defn deny-missing-tags
   [input]
-  (when-not (get-in input ["provider" "tags" "author"])
+  (when-not (get-in input [:provider :tags :author])
     "Should set provider tags for author"))

--- a/src/conjtest/bb/main.clj
+++ b/src/conjtest/bb/main.clj
@@ -79,7 +79,10 @@
           ["conjtest test deployment.yaml --policy policy.clj --config conjtest.edn"]
           []
           ["Config file can be provided to support local file requires via `:paths`. Eg:"]
-          ["{:paths [\"util/\"]}"]]
+          ["{:paths [\"util/\"]}"]
+          []
+          ["For keyworded keys, include `:keywordize?` in config file. Eg:"]
+          ["{:keywordize? true}"]]
    :spec {:config {:coerce :string
                    :alias :c
                    :desc "Filepath to configuration file"
@@ -120,8 +123,19 @@
           ["Examples:"]
           ["conjtest parse deployment.yaml"]
           ["conftest parse hocon.conf --parser hocon"]
-          ["conjtest parse deps.edn --parser edn --go-parsers-only"]]
-   :spec {:go-parsers-only {:coerce :boolean
+          ["conjtest parse deps.edn --parser edn --go-parsers-only"]
+          ["conjtest parse Dockerfile --config conjtest.edn"]
+          []
+          ["For keyworded keys, include `:keywordize?` in config file. Eg:"]
+          ["{:keywordize? true}"]]
+   :spec {:config {:coerce :string
+                   :alias :c
+                   :desc "Filepath to configuration file"
+                   :default nil
+                   :default-desc ""
+                   :validate {:pred (complement empty?)
+                              :ex-msg "--config must be non-empty string"}}
+          :go-parsers-only {:coerce :boolean
                             :alias :go
                             :desc "Use Go-based parsers only"}
           :help {:coerce :boolean
@@ -130,7 +144,7 @@
                    :desc "Use specific parser to parse files. Supported parsers: cue, dockerfile, edn, hcl1, hcl2, hocon, ignore, ini, json, jsonnet, properties, spdx, toml, vcl, xml, yaml, dotenv"
                    :validate {:pred (complement empty?)
                               :ex-msg (constantly "--parser must be non-empty string")}}}
-   :restrict [:go-parsers-only :help :parser]})
+   :restrict [:config :go-parsers-only :help :parser]})
 
 (defn test
   [args]

--- a/test.conjtest.edn
+++ b/test.conjtest.edn
@@ -1,1 +1,2 @@
-{:paths ["test-resources/"]}
+{:paths ["test-resources/"]
+ :keywordize? true}

--- a/test/conjtest/core_test.clj
+++ b/test/conjtest/core_test.clj
@@ -30,7 +30,7 @@
 
 (defn conjtest-test
   [inputs policies & extra-args]
-  (select-keys (apply conjtest-test* inputs policies extra-args) [:exit :out]))
+  (select-keys (apply conjtest-test* inputs policies (into ["--config" "test.conjtest.edn"] extra-args)) [:exit :out]))
 
 (defn conjtest-parse
   [inputs & extra-args]

--- a/test/conjtest/core_test.clj
+++ b/test/conjtest/core_test.clj
@@ -173,15 +173,13 @@
         (testing "pass"
           (is (= {:exit 0, :out [[] {:tests 1, :passed 1, :warnings 0, :failures 0}]}
                  (conjtest-test ["test-resources/valid.yaml"]
-                                ["test-resources/conjtest/example_local_require.clj"]
-                                "--config" "test.conjtest.edn"))))
+                                ["test-resources/conjtest/example_local_require.clj"]))))
         (testing "failure"
           (is (= {:exit 1,
                   :out [[{:type "FAIL", :file "test-resources/invalid.yaml", :rule "allow-allowlisted-selector-only", :message ":conjtest/rule-validation-failed"}]
                         {:tests 1, :passed 0, :warnings 0, :failures 1}]}
                  (conjtest-test ["test-resources/invalid.yaml"]
-                                ["test-resources/conjtest/example_local_require.clj"]
-                                "--config" "test.conjtest.edn"))))))
+                                ["test-resources/conjtest/example_local_require.clj"]))))))
     (testing "--trace"
       (testing "triggered"
         (is (= ["deny-my-absolute-bare-rule"

--- a/test/conjtest/core_test.clj
+++ b/test/conjtest/core_test.clj
@@ -460,7 +460,7 @@
                 :out [[{:type "FAIL",
                         :file "examples/json/package.json",
                         :rule "deny-caret-ranges",
-                        :message "caret ranges not allowed, offending library: [\"express\" \"^4.17.3\"]"}]
+                        :message "caret ranges not allowed, offending library: [:express \"^4.17.3\"]"}]
                       {:tests 1, :passed 0, :warnings 0, :failures 1}]}
                (conjtest-test ["examples/json/package.json"]
                               ["examples/json/policy_go.clj"]

--- a/test/conjtest/core_test.clj
+++ b/test/conjtest/core_test.clj
@@ -377,27 +377,27 @@
             :out [[{:type "FAIL",
                     :file "examples/hcl2/terraform.tf",
                     :rule "deny-fully-open-ingress",
-                    :message "ASG rule 'my-rule' defines a fully open ingress"}
+                    :message "ASG rule ':my-rule' defines a fully open ingress"}
                    {:type "FAIL",
                     :file "examples/hcl2/terraform.tf",
                     :rule "deny-http",
-                    :message "ALB listener 'my-alb-listener' is using HTTP rather than HTTPS"}
+                    :message "ALB listener ':my-alb-listener' is using HTTP rather than HTTPS"}
                    {:type "FAIL",
                     :file "examples/hcl2/terraform.tf",
                     :rule "deny-missing-tags",
-                    :message "AWS resource: aws_alb_listener named 'my-alb-listener' is missing required tags: #{\"owner\" \"environment\"}"}
+                    :message "AWS resource: :aws_alb_listener named ':my-alb-listener' is missing required tags: #{:environment :owner}"}
                    {:type "FAIL",
                     :file "examples/hcl2/terraform.tf",
                     :rule "deny-missing-tags",
-                    :message "AWS resource: aws_db_security_group named 'my-group' is missing required tags: #{\"owner\" \"environment\"}"}
+                    :message "AWS resource: :aws_db_security_group named ':my-group' is missing required tags: #{:environment :owner}"}
                    {:type "FAIL",
                     :file "examples/hcl2/terraform.tf",
                     :rule "deny-missing-tags",
-                    :message "AWS resource: aws_security_group_rule named 'my-rule' is missing required tags: #{\"owner\" \"environment\"}"}
+                    :message "AWS resource: :aws_security_group_rule named ':my-rule' is missing required tags: #{:environment :owner}"}
                    {:type "FAIL",
                     :file "examples/hcl2/terraform.tf",
                     :rule "deny-unencrypted-azure-disk",
-                    :message "Azure disk 'source' is not encrypted"}]
+                    :message "Azure disk ':source' is not encrypted"}]
                   {:tests 4, :passed 0, :warnings 0, :failures 4}]}
            (conjtest-test ["examples/hcl2/terraform.tf"]
                           ["examples/hcl2/policy.clj"]))))


### PR DESCRIPTION
Enables keyworded keys for parsed data results via `keywordize?`. This allows for more idiomatic access to Clojure data structures inside the rules, since the parsed data results consist mostly of maps anyway.

This option can be passed through a config file which is passed via the `--config` option for `test` and `parse` actions.

Using HCL2 file as an example, all map keys will be converted to keywords.

```clojure
$ cat conjtest.edn
{:keywordize? true}

$ conjtest parse examples/hcl2/terraform.tf --config conjtest.edn
{:resource
 {:aws_security_group_rule
  {:my-rule {:cidr_blocks ["0.0.0.0/0"], :type "ingress"}},
  :azurerm_managed_disk
  {:source {:encryption_settings {:enabled false}}},
  :aws_alb_listener {:my-alb-listener {:port "80", :protocol "HTTP"}},
  :aws_db_security_group {:my-group {}},
  :aws_s3_bucket
  {:valid
   {:acl "private",
    :bucket "validBucket",
    :tags {:environment "prod", :owner "devops"}}}}}
```

For rules, we won't need `get` and anonymous functions as much anymore since we can use keywords as functions directly (which is more idiomatic in Clojure).

```clojure
(defn deny-unencrypted-azure-disk
  [input]
  (for [[disk-name disk] (get-in input [:resource :azurerm_managed_disk])
        :let [encryption-settings (:encryption_settings disk)]
        :when (not (true? (:enabled encryption-settings)))]
    (format "Azure disk '%s' is not encrypted" disk-name)))
```

At the CLI interface level, we'll need to pass `--config conjtest.edn` explicitly in order to transform the keys.

```bash
$ conjtest test examples/hcl2/terraform.tf -p examples/hcl2/policy.clj --config conjtest.edn
FAIL - examples/hcl2/terraform.tf - deny-fully-open-ingress - ASG rule ':my-rule' defines a fully open ingress
FAIL - examples/hcl2/terraform.tf - deny-http - ALB listener ':my-alb-listener' is using HTTP rather than HTTPS
FAIL - examples/hcl2/terraform.tf - deny-missing-tags - AWS resource: :aws_alb_listener named ':my-alb-listener' is missing required tags: #{:environment :owner}
FAIL - examples/hcl2/terraform.tf - deny-missing-tags - AWS resource: :aws_db_security_group named ':my-group' is missing required tags: #{:environment :owner}
FAIL - examples/hcl2/terraform.tf - deny-missing-tags - AWS resource: :aws_security_group_rule named ':my-rule' is missing required tags: #{:environment :owner}
FAIL - examples/hcl2/terraform.tf - deny-unencrypted-azure-disk - Azure disk ':source' is not encrypted

4 tests, 0 passed, 0 warnings, 4 failures
```